### PR TITLE
Write items to Table and manually set headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ $writer = new ConsoleTableWriter(new Table($output));
 
 // ConsoleTableWriter can automatically detect and set the headers
 $writer->autoDetectHeader();
+
+// Headers can also be set manually. This is required when the item is an object
+$writer->setHeader(['Country', 'City']);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $writer = new ConsoleProgressWriter(new ProgressBar($output, $reader->count()));
 
 ```php
 use Plum\PlumConsole\ConsoleTableWriter;
+use Symfony\Component\Console\Helper\Table;
 
 // ...
 // $output is an instance of Symfony\Component\Console\Output\OutputInterface

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,11 @@
   "require": {
     "php":             ">=5.4",
     "symfony/console": "~2.5",
-    "plumphp/plum":    "~0.2"
+    "plumphp/plum":    "~0.2",
+    "cocur/vale":      "~0.2"
   },
   "require-dev": {
-    "phpunit/phpunit":    "~4.3",
+    "phpunit/phpunit":    "~4.8",
     "mockery/mockery":    "~0.9"
   },
   "autoload": {

--- a/src/ConsoleTableWriter.php
+++ b/src/ConsoleTableWriter.php
@@ -11,6 +11,8 @@
 
 namespace Plum\PlumConsole;
 
+use Cocur\Vale\Vale;
+use InvalidArgumentException;
 use Plum\Plum\Writer\WriterInterface;
 use Symfony\Component\Console\Helper\Table;
 
@@ -82,11 +84,12 @@ class ConsoleTableWriter implements WriterInterface
     public function writeItem($item)
     {
         if ($this->autoDetectHeader && !$this->header) {
-            $this->header = array_keys($item);
-            $this->table->setHeaders($this->header);
+            $this->handleAutoDetectHeader($item);
         }
 
-        $this->table->addRow($item);
+        $this->table->addRow(
+            $this->getValues($item, $this->getKeys($item))
+        );
     }
 
     /**
@@ -111,5 +114,56 @@ class ConsoleTableWriter implements WriterInterface
     public function finish()
     {
         $this->table->render();
+    }
+
+    /**
+     * @param mixed $item
+     */
+    protected function handleAutoDetectHeader($item)
+    {
+        if (!is_array($item)) {
+            throw new InvalidArgumentException('Plum\PlumConsole\ConsoleTableWriter can only auto detect headers for '.
+                                               'array items. For items of a type other than array the headers have '.
+                                               'to be set manually.');
+        }
+
+        $this->header = array_keys($item);
+        $this->table->setHeaders($this->header);
+    }
+
+    /**
+     * @param mixed $item
+     *
+     * @return string[]
+     */
+    protected function getKeys($item)
+    {
+        if (is_array($item)) {
+            return array_keys($item);
+        } else if ($this->header && is_object($item)) {
+            return $this->header;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Plum\PlumConsole\ConsoleTableWriter currently only supports array items or objects if headers '.
+            'are set using the setHeader() method. You have passed an item of type "%s" to writeItem().',
+            gettype($item)
+        ));
+    }
+
+    /**
+     * @param mixed    $item
+     * @param string[] $keys
+     *
+     * @return array
+     */
+    protected function getValues($item, array $keys)
+    {
+        $values = [];
+        foreach ($keys as $key) {
+            $values[] = Vale::get($item, $key);
+        }
+
+        return $values;
     }
 }

--- a/src/ConsoleTableWriter.php
+++ b/src/ConsoleTableWriter.php
@@ -49,6 +49,18 @@ class ConsoleTableWriter implements WriterInterface
     }
 
     /**
+     * @param string[] $header
+     *
+     * @return ConsoleTableWriter
+     */
+    public function setHeader(array $header)
+    {
+        $this->header = $header;
+
+        return $this;
+    }
+
+    /**
      * @param bool $autoDetectHeader
      *
      * @return ConsoleTableWriter
@@ -86,6 +98,9 @@ class ConsoleTableWriter implements WriterInterface
      */
     public function prepare()
     {
+        if ($this->header !== null) {
+            $this->table->setHeaders($this->header);
+        }
     }
 
     /**

--- a/tests/ConsoleTableWriterTest.php
+++ b/tests/ConsoleTableWriterTest.php
@@ -53,6 +53,21 @@ class ConsoleTableWriterTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @covers Plum\PlumConsole\ConsoleTableWriter::setHeader()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::prepare()
+     */
+    public function setHeaderShouldManuallySetHeaders()
+    {
+        $this->table->shouldReceive('setHeaders')->with(['a', 'b'])->once();
+        $this->table->shouldReceive('addRow')->with(['foo', 'bar'])->once();
+
+        $this->writer->setHeader(['a', 'b']);
+        $this->writer->prepare();
+        $this->writer->writeItem(['foo', 'bar']);
+    }
+
+    /**
+     * @test
      * @covers Plum\PlumConsole\ConsoleTableWriter::autoDetectHeader()
      * @covers Plum\PlumConsole\ConsoleTableWriter::writeItem()
      */

--- a/tests/ConsoleTableWriterTest.php
+++ b/tests/ConsoleTableWriterTest.php
@@ -13,6 +13,7 @@ namespace Plum\PlumConsole;
 
 use Mockery;
 use PHPUnit_Framework_TestCase;
+use stdClass;
 
 /**
  * ConsoleTableWriterTest
@@ -43,6 +44,8 @@ class ConsoleTableWriterTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @covers Plum\PlumConsole\ConsoleTableWriter::writeItem()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::getKeys()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::getValues()
      */
     public function writeItemAddsItemToTable()
     {
@@ -69,15 +72,59 @@ class ConsoleTableWriterTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @covers Plum\PlumConsole\ConsoleTableWriter::autoDetectHeader()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::handleAutoDetectHeader()
      * @covers Plum\PlumConsole\ConsoleTableWriter::writeItem()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::getKeys()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::getValues()
      */
     public function writeItemDetectsHeaderWithAutoDetectHeaderOption()
     {
         $this->table->shouldReceive('setHeaders')->with(['a', 'b'])->once();
-        $this->table->shouldReceive('addRow')->with(['a' => 'foo', 'b' => 'bar'])->once();
+        $this->table->shouldReceive('addRow')->with(['foo', 'bar'])->once();
 
         $this->writer->autoDetectHeader();
         $this->writer->writeItem(['a' => 'foo', 'b' => 'bar']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\PlumConsole\ConsoleTableWriter::writeItem()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::handleAutoDetectHeader()
+     * @expectedException \InvalidArgumentException
+     */
+    public function writeItemShouldThrowExceptionIfAutoDetectHeaderOptionAndItemNotArray()
+    {
+        $this->writer->autoDetectHeader();
+        $this->writer->writeItem(new stdClass());
+    }
+
+    /**
+     * @test
+     * @covers Plum\PlumConsole\ConsoleTableWriter::writeItem()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::getKeys()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::getValues()
+     */
+    public function writeItemShouldWriteItemsIfTheyAreObjects()
+    {
+        $item    = new stdClass();
+        $item->a = 'foo';
+        $item->b = 'bar';
+
+        $this->table->shouldReceive('addRow')->with(['foo', 'bar'])->once();
+
+        $this->writer->setHeader(['a', 'b']);
+        $this->writer->writeItem($item);
+    }
+
+    /**
+     * @test
+     * @covers Plum\PlumConsole\ConsoleTableWriter::writeItem()
+     * @covers Plum\PlumConsole\ConsoleTableWriter::getKeys()
+     * @expectedException \InvalidArgumentException
+     */
+    public function writeItemShouldThroughExceptionIfInvalidTypeGiven()
+    {
+        $this->writer->writeItem('invalid');
     }
 
     /**


### PR DESCRIPTION
Until now only arrays could be written to Table using `ConsoleTableWriter`. This PR adds the ability to write objects to the table (if headers are manually set). In addition it is now possible to manually set headers and the writers provides proper error handling and throws descriptive exception if an error occurred.
